### PR TITLE
Add the SETUP_ANNOTATIONS opcode as a no-op

### DIFF
--- a/unpyc3.py
+++ b/unpyc3.py
@@ -1846,6 +1846,9 @@ class SuiteDecompiler:
     def NOP(self, addr):
         return
 
+    def SETUP_ANNOTATIONS(self, addr):
+        return
+
     def COMPARE_OP(self, addr, compare_opname):
         left, right = self.stack.pop(2)
         if compare_opname != 10:  # 10 is exception match


### PR DESCRIPTION
The SETUP_ANNOTATIONS opcode works internally to the PVM, and doesn't relate to an explicit function call

From the [dis documentation](https://docs.python.org/3/library/dis.html#opcode-SETUP_ANNOTATIONS):

Checks whether `__annotations__` is defined in `locals()`, if not it is set up to an empty dict. This opcode is only emitted if a class or module body contains [variable annotations](https://docs.python.org/3/glossary.html#term-variable-annotation) statically.